### PR TITLE
Versioning Refactor

### DIFF
--- a/makefiles/versioning.mk
+++ b/makefiles/versioning.mk
@@ -2,37 +2,63 @@ ifndef .DEFAULT_GOAL
 .DEFAULT_GOAL := versioning-help
 endif
 
-GITVERSION_VERSION := latest
+ifndef DOCKER
+$(info ### Add the following include statement to your Makefile)
+$(info include makester/makefiles/docker.mk)
+$(error ### missing include dependency)
+endif
 
-# PACKAGE_NAME simulates PyPI package naming convention (replacing hyphens with underscores).
-MAKESTER__PACKAGE_NAME := $(shell echo $(MAKESTER__PROJECT_NAME) | tr - _)
+# Defaults.
+MAKESTER__GITVERSION_CONFIG ?= GitVersion.yml
+MAKESTER__GITVERSION_VARIABLE ?= AssemblySemFileVer
+MAKESTER__GITVERSION_VERSION ?= latest
 
-CMD ?= /h
+_dump_versioning:
+	$(shell which cat) $(MAKESTER__WORK_DIR)/versioning
+
 # GitVersion help (default).
-gitversion:
+CMD ?= /h
+_gitversion-cmd:
 	@$(DOCKER) run --rm\
  -v "$(MAKESTER__PROJECT_DIR):/$(MAKESTER__PACKAGE_NAME)"\
- gittools/gitversion:$(GITVERSION_VERSION) $(CMD) > $(MAKESTER__WORK_DIR)/versioning
+ gittools/gitversion:$(MAKESTER__GITVERSION_VERSION) $(CMD) > $(MAKESTER__WORK_DIR)/versioning
+
+gitversion: _gitversion-cmd _dump_versioning
 
 # GitVersion executable's version.
-gitversion-version: CMD = /version
+gitversion-version: _gitversion-version-msg _gitversion-version _dump_versioning
+_gitversion-version-msg:
+	$(info ### Current GitVersion version ...)
+_gitversion-version: CMD = /version
 
 # GitVersion version variables.
-GITVERSION_CONFIG ?= GitVersion.yml
-gitversion-versions: CMD =  /$(MAKESTER__PACKAGE_NAME) /config $(GITVERSION_CONFIG)
+_gitversion-versions: MAKESTER__PROJECT_DIR := $(MAKESTER__PROJECT_DIR)
+_gitversion-versions: MAKESTER__GITVERSION_CONFIG := $(MAKESTER__GITVERSION_CONFIG)
+_gitversion-versions: CMD = /$(MAKESTER__PACKAGE_NAME) /config $(MAKESTER__GITVERSION_CONFIG)
 
-gitversion-version gitversion-long gitversion-versions: gitversion
+_gitversion-versions-rm: MAKESTER__PROJECT_DIR := $(MAKESTER__PROJECT_DIR)
+_gitversion-versions-rm:
+	-@$(info ### removing $(MAKESTER__WORK_DIR)/versioning $(shell rm $(MAKESTER__WORK_DIR)/versioning))
 
-GITVERSION_VARIABLE ?= AssemblySemFileVer
-release-version: gitversion-versions
-	$(info ### Filtering GitVersion variable: $(GITVERSION_VARIABLE))
-	$(eval $(shell echo export MAKESTER__RELEASE_VERSION=$(shell sed -e 's/=.*$$// p' $(MAKESTER__WORK_DIR)/versioning | jq .$(GITVERSION_VARIABLE))))
-	$(info ### MAKESTER__RELEASE_VERSION: $(MAKESTER__RELEASE_VERSION))
+
+_gitversion-version _gitversion-versions: _gitversion-cmd
+
+release-version: _gitversion-versions
+	$(info ### Filtering GitVersion variable: $(MAKESTER__GITVERSION_VARIABLE))
+	$(shell sed -e 's/=.*$$// p' $(MAKESTER__WORK_DIR)/versioning | jq .$(MAKESTER__GITVERSION_VARIABLE) > $(MAKESTER__WORK_DIR)/release-version)
+	$(info ### MAKESTER__RELEASE_VERSION: $(shell cat $(MAKESTER__WORK_DIR)/release-version))
+
+_release-version-rm: MAKESTER__PROJECT_DIR := $(MAKESTER__PROJECT_DIR)
+_release-version-rm:
+	-@$(info ### removing $(MAKESTER__WORK_DIR)/release-version $(shell rm $(MAKESTER__WORK_DIR)/release-version))
+
+gitversion-clear: _release-version-rm _gitversion-versions-rm
 
 versioning-help:
 	@echo "(makefiles/versioning.mk)\n\
   gitversion           GitVersion usage message\n\
-  gitversion-versions  GitVersion version\n\
-  release-version      Filtered GitVersion variables (default: \"GITVERSION_VARIABLE\"=\"AssemblySemFileVer\")\n"
+  gitversion-clear     Clear the temporary GitVersion working files under \"$(MAKESTER__WORK_DIR)\"\n\
+  gitversion-version   The actual GitVersion version\n\
+  release-version      Filtered GitVersion variables against \"$(MAKESTER__GITVERSION_VARIABLE)\"\n"
 
 .PHONY: versioning-help

--- a/tests/test_versioning.bats
+++ b/tests/test_versioning.bats
@@ -1,0 +1,139 @@
+# Test runner.
+#
+# Can be executed manually with:
+#   tests/bats/bin/bats tests/test_versioning.bats
+#
+# bats file_tags=versioning
+setup() {
+    load 'test_helper/bats-support/load'
+    load 'test_helper/bats-assert/load'
+    export MAKESTER__WORK_DIR=$(mktemp -d -t makester-XXXXXX)
+}
+
+teardown() {
+    MAKESTER__PROJECT_DIR=$PWD make -f makefiles/makester.mk -f makefiles/docker.mk -f makefiles/versioning.mk gitversion-clear
+    rmdir $MAKESTER__WORK_DIR
+}
+
+# Versioning include dependencies.
+#
+# Docker.
+# bats test_tags=versioning-docker
+@test "Check docker executable dependency without makester.mk" {
+    run make -f makefiles/versioning.mk
+    assert_output --partial '### Add the following include statement to your Makefile
+include makester/makefiles/docker.mk'
+    [ "$status" -eq 2 ]
+}
+
+# bats test_tags=versioning-docker
+@test "Check docker executable dependency with makester.mk" {
+    DOCKER=dummy run make -f makefiles/versioning.mk
+    assert_output --partial '(makefiles/versioning.mk)'
+    [ "$status" -eq 0 ]
+}
+
+# Versioning variables.
+#
+# MAKESTER__GITVERSION_CONFIG
+# bats test_tags=MAKESTER__GITVERSION_CONFIG
+@test "MAKESTER__GITVERSION_CONFIG default should be set when calling versioning.mk" {
+    DOCKER=dummy run make -f makefiles/makester.mk -f makefiles/versioning.mk print-MAKESTER__GITVERSION_CONFIG
+    assert_output 'MAKESTER__GITVERSION_CONFIG=GitVersion.yml'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=MAKESTER__GITVERSION_CONFIG
+@test "MAKESTER__GITVERSION_CONFIG override" {
+    DOCKER=dummy MAKESTER__GITVERSION_CONFIG=Override.yml\
+ run make -f makefiles/makester.mk -f makefiles/versioning.mk print-MAKESTER__GITVERSION_CONFIG
+    assert_output 'MAKESTER__GITVERSION_CONFIG=Override.yml'
+    [ "$status" -eq 0 ]
+}
+
+# MAKESTER__GITVERSION_VARIABLE
+# bats test_tags=MAKESTER__GITVERSION_VARIABLE
+@test "MAKESTER__GITVERSION_VARIABLE default should be set when calling versioning.mk" {
+    DOCKER=dummy run make -f makefiles/makester.mk -f makefiles/versioning.mk print-MAKESTER__GITVERSION_VARIABLE
+    assert_output 'MAKESTER__GITVERSION_VARIABLE=AssemblySemFileVer'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=MAKESTER__GITVERSION_VARIABLE
+@test "MAKESTER__GITVERSION_VARIABLE override" {
+    DOCKER=dummy MAKESTER__GITVERSION_VARIABLE=Override\
+ run make -f makefiles/makester.mk -f makefiles/versioning.mk print-MAKESTER__GITVERSION_VARIABLE
+    assert_output 'MAKESTER__GITVERSION_VARIABLE=Override'
+    [ "$status" -eq 0 ]
+}
+
+# MAKESTER__GITVERSION_VERSION
+# bats test_tags=MAKESTER__GITVERSION_VERSION
+@test "MAKESTER__GITVERSION_VERSION default should be set when calling versioning.mk" {
+    DOCKER=dummy run make -f makefiles/makester.mk -f makefiles/versioning.mk print-MAKESTER__GITVERSION_VERSION
+    assert_output 'MAKESTER__GITVERSION_VERSION=latest'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=MAKESTER__GITVERSION_VERSION
+@test "MAKESTER__GITVERSION_VERSION override" {
+    DOCKER=dummy MAKESTER__GITVERSION_VERSION=override\
+ run make -f makefiles/makester.mk -f makefiles/versioning.mk print-MAKESTER__GITVERSION_VERSION
+    assert_output 'MAKESTER__GITVERSION_VERSION=override'
+    [ "$status" -eq 0 ]
+}
+
+# bats test_tags=MAKESTER__PACKAGE_NAME
+@test "MAKESTER__PACKAGE_NAME default should be set when calling versioning.mk" {
+    DOCKER=dummy run make -f makefiles/makester.mk -f makefiles/versioning.mk print-MAKESTER__PACKAGE_NAME
+    assert_output 'MAKESTER__PACKAGE_NAME=makefiles'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=MAKESTER__PACKAGE_NAME
+@test "MAKESTER__PACKAGE_NAME override" {
+    DOCKER=dummy MAKESTER__PACKAGE_NAME=override\
+ run make -f makefiles/makester.mk -f makefiles/versioning.mk print-MAKESTER__PACKAGE_NAME
+    assert_output 'MAKESTER__PACKAGE_NAME=override'
+    [ "$status" -eq 0 ]
+}
+
+# Targets.
+#
+# bats test_tags=gitversion-version
+@test "GitVersion version" {
+    MAKESTER__PROJECT_DIR=$PWD MAKESTER__GITVERSION_CONFIG=sample/GitVersion.yml\
+ run make -f makefiles/makester.mk -f makefiles/docker.mk -f makefiles/versioning.mk gitversion-version
+    assert_output --regexp '### Current GitVersion version ...
+[0-9]+\.[0-9]+\.[0-9]+\+Branch.support-5.x.Sha.[0-9a-z]+'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=MAKESTER__RELEASE_VERSION,release-version
+@test "Makester sample/GitVersion.yml release version" {
+    MAKESTER__PROJECT_DIR=$PWD MAKESTER__GITVERSION_CONFIG=sample/GitVersion.yml\
+ run make -f makefiles/makester.mk -f makefiles/docker.mk -f makefiles/versioning.mk release-version
+    assert_output --regexp '### Filtering GitVersion variable: AssemblySemFileVer
+### MAKESTER__RELEASE_VERSION: "[0-9]+\.[0-9]+\.[0-9a-z]+"'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=release-version
+@test "Makester sample/GitVersion.yml release version with overridden version variable" {
+    MAKESTER__PROJECT_DIR=$PWD MAKESTER__GITVERSION_CONFIG=sample/GitVersion.yml MAKESTER__GITVERSION_VARIABLE=ShortSha\
+ run make -f makefiles/makester.mk -f makefiles/docker.mk -f makefiles/versioning.mk release-version
+    assert_output --regexp '### Filtering GitVersion variable: ShortSha
+### MAKESTER__RELEASE_VERSION: "[0-9a-z]+"'
+    [ "$status" -eq 0 ]
+}
+
+# bats test_tags=release-version
+@test "Default GitVersion.yml release version" {
+    MAKESTER__PROJECT_DIR=$PWD\
+ run make -f makefiles/makester.mk -f makefiles/docker.mk -f makefiles/versioning.mk release-version
+    assert_output --regexp '### Filtering GitVersion variable: AssemblySemFileVer
+### MAKESTER__RELEASE_VERSION: "[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+"'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=release-version
+@test "Default GitVersion.yml release version with overridden version variable" {
+    MAKESTER__PROJECT_DIR=$PWD MAKESTER__GITVERSION_VARIABLE=ShortSha\
+ run make -f makefiles/makester.mk -f makefiles/docker.mk -f makefiles/versioning.mk release-version
+    assert_output --regexp '### Filtering GitVersion variable: ShortSha
+### MAKESTER__RELEASE_VERSION: "[0-9a-z]+"'
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
- Introduce additional Makester global variables to assist with the management of autonomous versioning.
- Release variable filtered state is stored under separate file under `MAKESTER__WORK_DIR` instead of being managed as a global environment variable.