### PR TITLE
Replace PyPI docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ make -f sample/Makefile run
 ```
 Finally, to clean up you can delete the `supa-cool-repo/my-project:99296c8` image:
 ```
-make -f sample/Makefile rmi
+make -f sample/Makefile irm
 ```
 ## Adding `Makester` to your Project's Git Repository
 
@@ -213,6 +213,14 @@ make py
 ### `makefiles/compose.mk`
 To use add `include makester/makefiles/compose.mk` to your `Makefile`.
 
+Traditional Makester capability has supported 
+[docker compose](https://docs.docker.com/engine/reference/commandline/compose/) capability as a basic
+multi-container orchestration facility. Makester strategy is to move more into the Kubernetes space so support
+for `makefiles/compose.mk` will continue to diminish over time.
+
+> **_NOTE:_** Support for PyPI `docker-compose` has been completely removed as there does not appear to be
+a roadmap within that project to move to [docker compose V2](https://docs.docker.com/compose/compose-v2/).
+
 As of [Moby 20.10.13](https://github.com/moby/moby/releases/tag/v20.10.13), [docker compose V2](https://docs.docker.com/compose/compose-v2/) is integrated into the Docker CLI. This means that we do not need to support the installation of the standalone [docker-compose](https://docs.docker.com/compose/install/other/).
 
 #### Variables
@@ -223,7 +231,7 @@ MAKESTER__COMPOSE_FILES = -f docker-compose-supa.yml
 If you need more control over `docker-compose`, then override the `MAKESTER__COMPOSE_RUN_CMD` parameter in your `Makefile`. For example, to specify the verbose output option:
 ```
 MAKESTER__COMPOSE_RUN_CMD ?= SERVICE_NAME=$(MAKESTER__PROJECT_NAME) HASH=$(HASH)\
- $(DOCKER_COMPOSE)\
+ $(MAKESTER__DOCKER_COMPOSE)\
  --verbose\
  $(MAKESTER__COMPOSE_FILES) $(COMPOSE_CMD)
 ```
@@ -258,7 +266,7 @@ make build-image
 ```
 The `build-image` target can be controlled by overrding the `MAKESTER__BUILD_COMMAND` parameter in your `Makefile`. For example:
 ```
-MAKESTER__BUILD_COMMAND := $(DOCKER) build -t $(MAKESTER__SERVICE_NAME):$(HASH) .
+MAKESTER__BUILD_COMMAND := $(MAKESTER__DOCKER) build -t $(MAKESTER__SERVICE_NAME):$(HASH) .
 ```
 ##### Run your Docker Images as a Container
 ```
@@ -266,7 +274,7 @@ make run
 ```
 The `run` target can be controlled in your `Makefile` by overriding the `MAKESTER__RUN_COMMAND` parameter. For example:
 ```
-MAKESTER__RUN_COMMAND := $(DOCKER) run --rm -d --name $(MAKESTER__CONTAINER_NAME) $(MAKESTER__SERVICE_NAME):$(HASH)
+MAKESTER__RUN_COMMAND := $(MAKESTER__DOCKER) run --rm -d --name $(MAKESTER__CONTAINER_NAME) $(MAKESTER__SERVICE_NAME):$(HASH)
 ```
 ##### Tag Docker Image with the `latest` Tag
 ```

--- a/makefiles/compose.mk
+++ b/makefiles/compose.mk
@@ -2,36 +2,46 @@ ifndef .DEFAULT_GOAL
 .DEFAULT_GOAL := compose-help
 endif
 
-# Look for podman. Falls through to docker.
-_DOCKER := $(shell which podman 2>/dev/null)
-ifndef _DOCKER
-_DOCKER := $(shell which docker 2>/dev/null)
+ifndef MAKESTER__DOCKER
+$(info ### Add the following include statement to your Makefile)
+$(info include makester/makefiles/docker.mk)
+$(error ### missing include dependency)
 endif
-$(call check-defined, _DOCKER, can't find a container compose spec: docker and podman supported)
-DOCKER_COMPOSE := $(shell which $(_DOCKER)-compose 2>/dev/null || echo "3env/bin/$(shell basename $(_DOCKER))-compose")
+
+MAKESTER__DOCKER_COMPOSE ?= $(MAKESTER__DOCKER) compose
 
 MAKESTER__COMPOSE_FILES ?= -f docker-compose.yml
 
+ifndef COMPOSE_CMD
+override COMPOSE_CMD = version
+endif
 MAKESTER__COMPOSE_RUN_CMD ?= SERVICE_NAME=$(MAKESTER__SERVICE_NAME) HASH=$(HASH)\
- $(DOCKER_COMPOSE)\
+ $(MAKESTER__DOCKER_COMPOSE)\
  --project-name $(MAKESTER__PROJECT_NAME)\
  $(MAKESTER__COMPOSE_FILES) $(COMPOSE_CMD)
 
-compose-cmd:
+_compose-cmd:
 	@$(MAKESTER__COMPOSE_RUN_CMD)
 
 compose-config: COMPOSE_CMD = config
 
-compose-up: COMPOSE_CMD = up -d
-
 compose-down: COMPOSE_CMD = down -v
 
-compose-config compose-up compose-down: compose-cmd
+compose-ls: COMPOSE_CMD = ls
+
+compose-ps: COMPOSE_CMD = ps
+
+compose-up: COMPOSE_CMD = up -d
+
+compose-config compose-down compose-ls compose-ps compose-up compose-version: _compose-cmd
 
 compose-help:
 	@echo "(makefiles/compose.mk)\n\
   compose-config       Compose stack \"$(MAKESTER__PROJECT_NAME)\" config ($(MAKESTER__COMPOSE_FILES))\n\
+  compose-down         Compose stack \"$(MAKESTER__PROJECT_NAME)\" destroy (including volumes)\n\
+  compose-ls           List running compose projects\n\
+  compose-ps           List running compose containers\n\
   compose-up           Compose stack \"$(MAKESTER__PROJECT_NAME)\" create ($(MAKESTER__COMPOSE_FILES))\n\
-  compose-down         Compose stack \"$(MAKESTER__PROJECT_NAME)\" destroy (including volumes)\n"
+  compose-version      Compose version\n"
 
 .PHONY: compose-help

--- a/makefiles/docker.mk
+++ b/makefiles/docker.mk
@@ -2,106 +2,126 @@ ifndef .DEFAULT_GOAL
 .DEFAULT_GOAL := docker-help
 endif
 
+ifndef MAKESTER__PRIMED
+$(info ### Add the following include statement to your Makefile)
+$(info include makester/makefiles/makester.mk)
+$(error ### missing include dependency)
+endif
+
 # Docker is needed.
-DOCKER ?= $(call check-exe,docker,https://docs.docker.com/get-docker/)
+MAKESTER__DOCKER ?= $(call check-exe,docker,https://docs.docker.com/get-docker/)
 
 MAKESTER__CONTAINER_NAME ?= my-container
 MAKESTER__IMAGE_TARGET_TAG ?= $(HASH)
 
-MAKESTER__RUN_COMMAND ?= $(DOCKER) run --rm --name $(MAKESTER__CONTAINER_NAME) $(MAKESTER__SERVICE_NAME):$(HASH)
+MAKESTER__RUN_COMMAND ?= $(MAKESTER__DOCKER) run --rm --name $(MAKESTER__CONTAINER_NAME) $(MAKESTER__SERVICE_NAME):$(HASH)
 
-MAKESTER__BUILD_COMMAND ?= $(DOCKER) build -t $(MAKESTER__SERVICE_NAME):$(HASH) .
+MAKESTER__BUILD_COMMAND ?= $(MAKESTER__DOCKER) build -t $(MAKESTER__SERVICE_NAME):$(HASH) .
 
-si: search-image
-search-image:
-	-$(DOCKER) images "$(MAKESTER__SERVICE_NAME)*"
+# 20221027: Introduced target grouping for "image" related items.
+is image-search si search-image:
+	-$(MAKESTER__DOCKER) images "$(MAKESTER__SERVICE_NAME)*"
 
-bi: build-image
-
-build-image:
+ib image-build bi build-image:
 	$(MAKESTER__BUILD_COMMAND)
 
-rmi rm-image: rm-image-cmd
+irm image-rm rmi rm-image:
+	$(MAKESTER__DOCKER) rmi $(MAKESTER__IMAGE_TAG_ALIAS)
 
-rm-image-cmd:
-	$(DOCKER) rmi $(MAKESTER__IMAGE_TAG_ALIAS)
+IMAGE_TAG_ID := $(shell $(MAKESTER__DOCKER) images --filter=reference=$(MAKESTER__SERVICE_NAME) --format "{{.ID}}" | head -1)
+MAKESTER__IMAGE_TAG_ALIAS ?= $(MAKESTER__SERVICE_NAME):$(MAKESTER__IMAGE_TARGET_TAG)
+image-tag tag tag-image:
+	-$(MAKESTER__DOCKER) tag $(IMAGE_TAG_ID) $(MAKESTER__IMAGE_TAG_ALIAS)
 
-run:
+_image-tag-msg:
+	$(info ### Tagging container image "$(MAKESTER__SERVICE_NAME)" as "$(MAKESTER__IMAGE_TARGET_TAG)")
+_image-tag-rm-msg:
+	$(info ### Removing tag "$(MAKESTER__IMAGE_TARGET_TAG)" from container image "$(MAKESTER__SERVICE_NAME)")
+
+image-tag-latest tag-latest: MAKESTER__IMAGE_TARGET_TAG = latest
+image-tag-latest tag-latest: _image-tag-msg tag
+
+image-tag-latest-rm tag-rm-latest: MAKESTER__IMAGE_TARGET_TAG = latest
+image-tag-latest-rm tag-rm-latest: _image-tag-rm-msg rmi
+
+image-tag-version tag-version: MAKESTER__IMAGE_TARGET_TAG = $(MAKESTER__VERSION)-$(MAKESTER__RELEASE_NUMBER)
+image-tag-version tag-version: _image-tag-msg tag
+
+image-tag-version-rm tag-rm-version: MAKESTER__IMAGE_TARGET_TAG = $(MAKESTER__VERSION)-$(MAKESTER__RELEASE_NUMBER)
+image-tag-version-rm tag-rm-version: _image-tag-rm-msg rmi
+
+image-tag-main tag-main: MAKESTER__IMAGE_TARGET_TAG = $(MAKESTER__VERSION)
+image-tag-main tag-main: _image-tag-msg tag
+
+image-tag-main-rm tag-rm-main: MAKESTER__IMAGE_TARGET_TAG = $(MAKESTER__VERSION)
+image-tag-main-rm tag-rm-main: _image-tag-rm-msg rmi
+
+image-tag-suite: image-tag-latest image-tag-main image-tag-version
+	$(info ### Container image tag create suite ...)
+	$(MAKE) image-tag-latest
+	$(MAKE) image-tag-main
+	$(MAKE) image-tag-version
+image-tag-suite-rm:
+	$(info ### Container image tag delete suite ...)
+	$(MAKE) image-tag-latest-rm
+	$(MAKE) image-tag-main-rm
+	$(MAKE) image-tag-version-rm
+
+image-push:
+	-$(MAKESTER__DOCKER) push $(MAKESTER__IMAGE_TAG_ALIAS)
+
+image-rm-dangling rm-dangling-images:
+	-$(shell $(MAKESTER__DOCKER) rmi $(shell $(MAKESTER__DOCKER) images -f "dangling=true" -q))
+
+# 20221027: Introduced target grouping for "container" related items.
+container-run run:
 	-$(MAKESTER__RUN_COMMAND)
 
-stop:
-	-$(DOCKER) stop $(MAKESTER__CONTAINER_NAME)
+container-stop stop:
+	-$(MAKESTER__DOCKER) stop $(MAKESTER__CONTAINER_NAME)
 
-root:
-	-$(DOCKER) exec -ti -u 0 $(MAKESTER__CONTAINER_NAME) sh || true
+container-root root:
+	-$(MAKESTER__DOCKER) exec -ti -u 0 $(MAKESTER__CONTAINER_NAME) sh || true
 
-sh:
-	-$(DOCKER) exec -ti $(MAKESTER__CONTAINER_NAME) sh || true
+container-sh sh:
+	-$(MAKESTER__DOCKER) exec -ti $(MAKESTER__CONTAINER_NAME) sh || true
 
-bash:
-	-$(DOCKER) exec -ti $(MAKESTER__CONTAINER_NAME) bash || true
+container-bash bash:
+	-$(MAKESTER__DOCKER) exec -ti $(MAKESTER__CONTAINER_NAME) bash || true
 
-logs:
-	-$(DOCKER) logs --follow $(MAKESTER__CONTAINER_NAME)
+container-logs logs:
+	-$(MAKESTER__DOCKER) logs --follow $(MAKESTER__CONTAINER_NAME)
 
-RUNNING_CONTAINER := $($(DOCKER) ps | grep $(MAKESTER__CONTAINER_NAME) | rev | cut -d' ' -f 1 | rev)
-status:
+RUNNING_CONTAINER := $($(MAKESTER__DOCKER) ps | grep $(MAKESTER__CONTAINER_NAME) | rev | cut -d' ' -f 1 | rev)
+container-status status:
 ifneq ($(RUNNING_CONTAINER),)
 	@echo \"$(MAKESTER__CONTAINER_NAME)\" Docker container is running.  Run \"make stop\" to terminate
 else
 	@echo \"$(MAKESTER__CONTAINER_NAME)\" Docker container not running. Run \"make run\" to start
 endif
 
-IMAGE_TAG_ID = $(shell $(DOCKER) images --filter=reference=$(MAKESTER__SERVICE_NAME) --format "{{.ID}}" | head -1)
-MAKESTER__IMAGE_TAG_ALIAS = $(MAKESTER__SERVICE_NAME):$(MAKESTER__IMAGE_TARGET_TAG)
-tag tag-image:
-	-$(DOCKER) tag $(IMAGE_TAG_ID) $(MAKESTER__IMAGE_TAG_ALIAS)
-
-tag-latest: MAKESTER__IMAGE_TARGET_TAG = latest
-tag-latest: tag
-
-tag-rm-latest: MAKESTER__IMAGE_TARGET_TAG = latest
-tag-rm-latest: rmi
-
-tag-version: MAKESTER__IMAGE_TARGET_TAG = $(MAKESTER__VERSION)-$(MAKESTER__RELEASE_NUMBER)
-tag-version: tag
-
-tag-rm-version: MAKESTER__IMAGE_TARGET_TAG = $(MAKESTER__VERSION)-$(MAKESTER__RELEASE_NUMBER)
-tag-rm-version: rmi
-
-tag-main: MAKESTER__IMAGE_TARGET_TAG = $(MAKESTER__VERSION)
-tag-main: tag
-
-tag-rm-main: MAKESTER__IMAGE_TARGET_TAG = $(MAKESTER__VERSION)
-tag-rm-main: rmi
-
-image-push:
-	-$(DOCKER) push $(MAKESTER__IMAGE_TAG_ALIAS)
-
-rm-dangling-images:
-	$(shell $(DOCKER) rmi $($(DOCKER) images -q -f dangling=true`))
-
 docker-help:
 	@echo "(makefiles/docker.mk)\n\
-  build-image          Build docker image and tag as $(MAKESTER__IMAGE_TAG_ALIAS) (alias bi)\n\
-  rm-image             Delete docker image \"$(MAKESTER__IMAGE_TAG_ALIAS)\" (alias rmi)\n\
-  search-image         List docker images that match \"$(MAKESTER__SERVICE_NAME)*\" (alias si)\n\
-  status               Check container $(MAKESTER__CONTAINER_NAME) run status\n\
-  run                  Run image $(MAKESTER__SERVICE_NAME):$(HASH) as $(MAKESTER__CONTAINER_NAME)\n\
-  root                 Shell on container $(MAKESTER__CONTAINER_NAME) as user \"root\"\n\
-  sh                   Shell on container $(MAKESTER__CONTAINER_NAME) as \"USER\"\n\
-  bash                 Bash on container $(MAKESTER__CONTAINER_NAME) as \"USER\"\n\
-  logs                 Follow container $(MAKESTER__CONTAINER_NAME) logs (Ctrl-C to end)\n\
-  stop                 Stop container $(MAKESTER__CONTAINER_NAME)\n\
-  tag-image            Tag image $(MAKESTER__SERVICE_NAME) \"$(HASH)\"\n\
-  tag-rm-image         Undo \"tag-image\"\n\
-  tag-latest           Tag image $(MAKESTER__SERVICE_NAME) \"latest\"\n\
-  tag-rm-latest        Undo \"tag-latest\"\n\
-  tag-version          Tag image $(MAKESTER__SERVICE_NAME) \"$(MAKESTER__VERSION)-$(MAKESTER__RELEASE_NUMBER)\"\n\
-  tag-rm-version       Undo \"tag-version\"\n\
-  tag-main             Tag image $(MAKESTER__SERVICE_NAME) \"$(MAKESTER__VERSION)\"\n\
-  tag-rm-main          Undo \"tag-main\"\n\
-  rm-dangling-images   Remove all dangling images\n\
-  image-push           Push image \"$(MAKESTER__IMAGE_TAG_ALIAS)\"\n"
+  container-bash       Bash on container $(MAKESTER__CONTAINER_NAME) as \"USER\"\n\
+  container-logs       Follow container $(MAKESTER__CONTAINER_NAME) logs (Ctrl-C to end)\n\
+  container-root       Shell on container $(MAKESTER__CONTAINER_NAME) as user \"root\"\n\
+  container-run        Run image $(MAKESTER__SERVICE_NAME):$(HASH) as $(MAKESTER__CONTAINER_NAME)\n\
+  container-sh         Shell on container $(MAKESTER__CONTAINER_NAME) as \"USER\"\n\
+  container-status     Check container $(MAKESTER__CONTAINER_NAME) run status\n\
+  container-stop       Stop container $(MAKESTER__CONTAINER_NAME)\n\
+  image-build          Build docker image and tag as $(MAKESTER__IMAGE_TAG_ALIAS) (alias bi)\n\
+  image-push           Push image \"$(MAKESTER__IMAGE_TAG_ALIAS)\"\n\
+  image-rm             Delete docker image \"$(MAKESTER__IMAGE_TAG_ALIAS)\" (alias rmi)\n\
+  image-rm-dangling    Remove all dangling images\n\
+  image-search         List docker images that match \"$(MAKESTER__SERVICE_NAME)*\" (alias si)\n\
+  image-tag            Tag image $(MAKESTER__SERVICE_NAME) \"$(HASH)\" (as per default build)\n\
+  image-tag-latest     Tag image $(MAKESTER__SERVICE_NAME) \"latest\"\n\
+  image-tag-latest-rm  Undo \"image-tag-latest\"\n\
+  image-tag-main       Tag image $(MAKESTER__SERVICE_NAME) \"$(MAKESTER__VERSION)\"\n\
+  image-tag-main-rm    Undo \"image-tag-main\"\n\
+  image-tag-suite      Convenience image create and tag all-in-one helper\n\
+  image-tag-suite-rm   Convenience image tag and image delete all-in-one helper\n\
+  image-tag-version    Tag image $(MAKESTER__SERVICE_NAME) \"$(MAKESTER__VERSION)-$(MAKESTER__RELEASE_NUMBER)\"\n\
+  image-tag-version-rm Undo \"image-tag-version\"\n"
 
 .PHONY: docker-help

--- a/makefiles/versioning.mk
+++ b/makefiles/versioning.mk
@@ -2,7 +2,7 @@ ifndef .DEFAULT_GOAL
 .DEFAULT_GOAL := versioning-help
 endif
 
-ifndef DOCKER
+ifndef MAKESTER__DOCKER
 $(info ### Add the following include statement to your Makefile)
 $(info include makester/makefiles/docker.mk)
 $(error ### missing include dependency)
@@ -23,7 +23,7 @@ _gitversion-cmd: MAKESTER__WORK_DIR := $(MAKESTER__WORK_DIR)
 _gitversion-cmd: MAKESTER__GITVERSION_CONFIG := $(MAKESTER__GITVERSION_CONFIG)
 _gitversion-cmd: makester-work-dir
 _gitversion-cmd:
-	@$(DOCKER) run --rm\
+	@$(MAKESTER__DOCKER) run --rm\
  -v "$(MAKESTER__PROJECT_DIR):/$(MAKESTER__PACKAGE_NAME)"\
  gittools/gitversion:$(MAKESTER__GITVERSION_VERSION) $(CMD) > $(MAKESTER__WORK_DIR)/versioning
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,3 @@
-# Infrastructure stack management.
-docker-compose
-podman-compose
-
 # Service management.
 backoff
 

--- a/sample/Makefile
+++ b/sample/Makefile
@@ -5,9 +5,8 @@ MAKESTER__CONTAINER_NAME := mega-container
 include makefiles/makester.mk
 include makefiles/docker.mk
 include makefiles/python-venv.mk
-include makefiles/versioning.mk
 
-MAKESTER__BUILD_COMMAND = $(DOCKER) build -t $(MAKESTER__SERVICE_NAME):$(HASH) sample
+MAKESTER__BUILD_COMMAND = $(MAKESTER__DOCKER) build -t $(MAKESTER__SERVICE_NAME):$(HASH) sample
 
 init: pip-requirements
 

--- a/sample/docker-compose.yml
+++ b/sample/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+
+services:
+    redis:
+        image: nginxdemos/hello
+        container_name: makester-example
+        ports:
+            - $SAMPLE_COMPOSE_PORT:80

--- a/tests/test_compose.bats
+++ b/tests/test_compose.bats
@@ -1,0 +1,63 @@
+# Test runner.
+#
+# Can be executed manually with:
+#   tests/bats/bin/bats --file-filter compose tests
+#
+# bats file_tags=compose
+setup() {
+    load 'test_helper/common-setup'
+    _common_setup
+}
+
+# Makester include dependencies.
+#
+# Docker.
+# bats test_tags=compose-dependencies
+@test "Check docker executable dependency without makester.mk" {
+    run make -f makefiles/compose.mk
+    assert_output --partial '### Add the following include statement to your Makefile
+include makester/makefiles/docker.mk'
+    [ "$status" -eq 2 ]
+}
+# bats test_tags=compose-dependencies
+@test "Check docker executable dependency with makester.mk" {
+    MAKESTER__DOCKER=dummy run make -f makefiles/compose.mk compose-help
+    assert_output --partial '(makefiles/compose.mk)'
+    [ "$status" -eq 0 ]
+}
+
+# Compose variables.
+#
+# MAKESTER__COMPOSE_FILES
+# bats test_tags=variables,compose-variables,MAKESTER__COMPOSE_FILES
+@test "MAKESTER__COMPOSE_FILES default should be set when calling compose.mk" {
+    MAKESTER__DOCKER=dummy run make -f makefiles/makester.mk -f makefiles/compose.mk print-MAKESTER__COMPOSE_FILES
+    assert_output 'MAKESTER__COMPOSE_FILES=-f docker-compose.yml'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=variables,compose-variables,MAKESTER__COMPOSE_FILES
+@test "MAKESTER__COMPOSE_FILES override" {
+    MAKESTER__DOCKER=dummy MAKESTER__COMPOSE_FILES="-f sample/docker-compose.yml"\
+ run make -f makefiles/makester.mk -f makefiles/compose.mk print-MAKESTER__COMPOSE_FILES
+    assert_output 'MAKESTER__COMPOSE_FILES=-f sample/docker-compose.yml'
+    [ "$status" -eq 0 ]
+}
+
+# MAKESTER__COMPOSE_RUN_CMD
+# bats test_tags=variables,compose-variables,MAKESTER__COMPOSE_RUN_CMD
+@test "MAKESTER__COMPOSE_RUN_CMD default should be set when calling compose.mk" {
+    MAKESTER__PROJECT_NAME=makester MAKESTER__DOCKER=docker\
+ run make -f makefiles/makester.mk -f makefiles/compose.mk print-MAKESTER__COMPOSE_RUN_CMD
+    assert_output --regexp "MAKESTER__COMPOSE_RUN_CMD=\
+SERVICE_NAME=makester HASH=[0-9a-z]{7} docker compose --project-name makester -f docker-compose.yml version"
+    [ "$status" -eq 0 ]
+}
+
+# Targets.
+# bats test_tags=targets,compose-targets,compose-version
+@test "Default Docker image tag: dry" {
+    MAKESTER__PROJECT_NAME=makester\
+ run make -f makefiles/makester.mk -f makefiles/docker.mk -f makefiles/compose.mk compose-version
+    assert_output --regexp '^Docker Compose version [v]{0,1}[0-9]{1}\.[0-9]{1,2}\.[0-9]{1,3}'
+    [ "$status" -eq 0 ]
+}

--- a/tests/test_compose_stack.bats
+++ b/tests/test_compose_stack.bats
@@ -1,0 +1,71 @@
+# Test runner.
+#
+# Can be executed manually with:
+#   tests/bats/bin/bats --file-filter compose-stack tests
+#
+# bats file_tags=compose-stack
+setup_file() {
+    export SAMPLE_COMPOSE_PORT=$(shuf -i 29000-29999 -n 1)
+    MAKESTER__DOCKER=docker MAKESTER__PROJECT_NAME=makester MAKESTER__COMPOSE_FILES="-f sample/docker-compose.yml"\
+ run make -f makefiles/makester.mk -f makefiles/compose.mk compose-up
+}
+setup() {
+    load 'test_helper/common-setup'
+    _common_setup
+}
+teardown_file() {
+    MAKESTER__DOCKER=docker MAKESTER__PROJECT_NAME=makester MAKESTER__COMPOSE_FILES="-f sample/docker-compose.yml"\
+ run make -f makefiles/makester.mk -f makefiles/compose.mk compose-down
+}
+
+# Compose config
+# 
+# bats test_tags=compose-config
+@test "Sample Compose stack config output" {
+    MAKESTER__DOCKER=docker MAKESTER__PROJECT_NAME=makester MAKESTER__COMPOSE_FILES="-f sample/docker-compose.yml"\
+ run make -f makefiles/makester.mk -f makefiles/compose.mk compose-config
+    assert_output "name: makester
+services:
+  redis:
+    container_name: makester-example
+    image: nginxdemos/hello
+    networks:
+      default: null
+    ports:
+    - mode: ingress
+      target: 80
+      published: \"$SAMPLE_COMPOSE_PORT\"
+      protocol: tcp
+networks:
+  default:
+    name: makester_default"
+    [ "$status" -eq 0 ]
+}
+
+# Compose stack.
+#
+# bats test_tags=compose-stack-status
+@test "Sample Compose stack HTTP response" {
+    result="$(wget -qO- --server-response localhost:$SAMPLE_COMPOSE_PORT 2>&1 | awk '/^  HTTP/{print $2}')"
+    [ "$result" -eq 200 ]
+}
+
+# Targets.
+# bats test_tags=targets,compose-ls
+@test "Sample Compose application listing" {
+    MAKESTER__PROJECT_NAME=makester\
+ run make -f makefiles/makester.mk -f makefiles/docker.mk -f makefiles/compose.mk compose-ls
+    assert_output --regexp 'NAME                STATUS              CONFIG FILES
+makester            running\(1\)          .*/makester/sample/docker-compose.yml'
+    [ "$status" -eq 0 ]
+}
+
+# bats test_tags=targets,compose-ps
+@test "Sample Compose container listing" {
+    MAKESTER__PROJECT_NAME=makester\
+ run make -f makefiles/makester.mk -f makefiles/docker.mk -f makefiles/compose.mk compose-ps
+    assert_output --partial "\
+NAME                COMMAND                  SERVICE             STATUS              PORTS
+makester-example    \"/docker-entrypoint.…\"   redis               running             0.0.0.0:$SAMPLE_COMPOSE_PORT->80/tcp"
+    [ "$status" -eq 0 ]
+}

--- a/tests/test_docker.bats
+++ b/tests/test_docker.bats
@@ -1,0 +1,126 @@
+# Test runner.
+#
+# Can be executed manually with:
+#   tests/bats/bin/bats --filter-tags docker tests
+#
+# bats file_tags=docker
+setup() {
+    load 'test_helper/common-setup'
+    _common_setup
+}
+
+# Docker include dependencies.
+#
+# Makester.
+# bats test_tags=docker-dependencies
+@test "Check if Makester is primed: false" {
+    run make -f makefiles/docker.mk
+    assert_output --partial '### Add the following include statement to your Makefile
+include makester/makefiles/makester.mk'
+    [ "$status" -eq 2 ]
+}
+# bats test_tags=docker-dependencies
+@test "Check if Makester is primed: true" {
+    run make -f makefiles/makester.mk -f makefiles/docker.mk docker-help
+    assert_output --partial '(makefiles/docker.mk)'
+    [ "$status" -eq 0 ]
+}
+
+# Docker variables.
+#
+# MAKESTER__CONTAINER_NAME
+# bats test_tags=variables,docker-variables,MAKESTER__CONTAINER_NAME
+@test "MAKESTER__CONTAINER_NAME default should be set when calling docker.mk" {
+    MAKESTER__DOCKER=docker\
+ run make -f makefiles/makester.mk -f makefiles/docker.mk print-MAKESTER__CONTAINER_NAME
+    assert_output 'MAKESTER__CONTAINER_NAME=my-container'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=variables,docker-variables,MAKESTER__CONTAINER_NAME
+@test "MAKESTER__CONTAINER_NAME override" {
+    MAKESTER__DOCKER=docker MAKESTER__CONTAINER_NAME=override\
+ run make -f makefiles/makester.mk -f makefiles/docker.mk print-MAKESTER__CONTAINER_NAME
+    assert_output 'MAKESTER__CONTAINER_NAME=override'
+    [ "$status" -eq 0 ]
+}
+
+# MAKESTER__IMAGE_TARGET_TAG
+# bats test_tags=variables,docker-variables,MAKESTER__IMAGE_TARGET_TAG
+@test "MAKESTER__IMAGE_TARGET_TAG default should be set to HASH when calling docker.mk" {
+    MAKESTER__DOCKER=docker\
+ run make -f makefiles/makester.mk -f makefiles/docker.mk print-MAKESTER__IMAGE_TARGET_TAG
+    assert_output --regexp '^MAKESTER__IMAGE_TARGET_TAG=[0-9a-z]{7}$'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=variables,docker-variables,MAKESTER__IMAGE_TARGET_TAG
+@test "MAKESTER__IMAGE_TARGET_TAG override" {
+    MAKESTER__DOCKER=docker MAKESTER__IMAGE_TARGET_TAG=override\
+ run make -f makefiles/makester.mk -f makefiles/docker.mk print-MAKESTER__IMAGE_TARGET_TAG
+    assert_output 'MAKESTER__IMAGE_TARGET_TAG=override'
+    [ "$status" -eq 0 ]
+}
+
+# MAKESTER__RUN_COMMAND
+# bats test_tags=variables,docker-variables,MAKESTER__RUN_COMMAND
+@test "MAKESTER__RUN_COMMAND default should be set when calling docker.mk" {
+    run make -f makefiles/makester.mk -f makefiles/docker.mk print-MAKESTER__RUN_COMMAND
+    assert_output --regexp '^MAKESTER__RUN_COMMAND=.*/docker run --rm --name my-container makefiles:[0-9a-z]{7}$'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=variables,docker-variables,MAKESTER__RUN_COMMAND
+@test "MAKESTER__RUN_COMMAND override" {
+    MAKESTER__RUN_COMMAND="\$(MAKESTER__DOCKER) run hello-world"\
+ run make -f makefiles/makester.mk -f makefiles/docker.mk print-MAKESTER__RUN_COMMAND
+    assert_output --regexp 'MAKESTER__RUN_COMMAND=.*/docker run hello-world'
+    [ "$status" -eq 0 ]
+}
+
+# MAKESTER__BUILD_COMMAND
+# bats test_tags=variables,docker-variables,MAKESTER__BUILD_COMMAND
+@test "MAKESTER__BUILD_COMMAND default should be set when calling docker.mk" {
+    run make -f makefiles/makester.mk -f makefiles/docker.mk print-MAKESTER__BUILD_COMMAND
+    assert_output --regexp '^MAKESTER__BUILD_COMMAND=.*/docker build -t makefiles:[0-9a-z]{7} \.$'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=variables,docker-variables,MAKESTER__BUILD_COMMAND
+@test "MAKESTER__BUILD_COMMAND override" {
+    MAKESTER__BUILD_COMMAND="\$(MAKESTER__DOCKER) build --no-cache -t \$(MAKESTER__IMAGE_TAG_ALIAS) ."\
+ run make -f makefiles/makester.mk -f makefiles/docker.mk print-MAKESTER__BUILD_COMMAND
+    assert_output --regexp '^MAKESTER__BUILD_COMMAND=.*/docker build --no-cache -t makefiles:[0-9a-z]{7} \.$'
+    [ "$status" -eq 0 ]
+}
+
+# MAKESTER__IMAGE_TAG_ALIAS
+# bats test_tags=variables,docker-variables,MAKESTER__IMAGE_TAG_ALIAS
+@test "MAKESTER__IMAGE_TAG_ALIAS default should be set when calling docker.mk" {
+    MAKESTER__PROJECT_NAME=makester\
+ run make -f makefiles/makester.mk -f makefiles/docker.mk print-MAKESTER__IMAGE_TAG_ALIAS
+    assert_output --regexp '^MAKESTER__IMAGE_TAG_ALIAS=makester:[0-9a-z]{7}$'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=variables,docker-variables,MAKESTER__IMAGE_TAG_ALIAS
+@test "MAKESTER__IMAGE_TAG_ALIAS override" {
+    MAKESTER__PROJECT_NAME=makester MAKESTER__IMAGE_TARGET_TAG="\$(MAKESTER__VERSION)-\$(MAKESTER__RELEASE_NUMBER)"\
+ run make -f makefiles/makester.mk -f makefiles/docker.mk print-MAKESTER__IMAGE_TAG_ALIAS
+    assert_output 'MAKESTER__IMAGE_TAG_ALIAS=makester:0.0.0-1'
+    [ "$status" -eq 0 ]
+}
+
+# Targets.
+#
+# bats test_tags=targets,docker-targets,image-tag,dry-run
+@test "Default Docker image tag: dry" {
+    MAKESTER__PROJECT_NAME=makester MAKESTER__DOCKER=docker\
+ run make -f makefiles/makester.mk -f makefiles/docker.mk image-tag --dry-run
+    assert_output --regexp '^docker tag  makester:[0-9a-z]{7}$'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=targets,docker-targets,image-tag,dry-run
+@test "Default Docker image tag override: dry" {
+    MAKESTER__PROJECT_NAME=makester\
+ MAKESTER__DOCKER=docker\
+ MAKESTER__IMAGE_TARGET_TAG="\$(MAKESTER__VERSION)-\$(MAKESTER__RELEASE_NUMBER)"\
+ run make -f makefiles/makester.mk -f makefiles/docker.mk image-tag --dry-run
+    assert_output 'docker tag  makester:0.0.0-1'
+    [ "$status" -eq 0 ]
+}

--- a/tests/test_docker_image.bats
+++ b/tests/test_docker_image.bats
@@ -1,0 +1,111 @@
+# Test runner.
+#
+# Can be executed manually with:
+#   tests/bats/bin/bats --filter-tags docker_sample tests
+#
+# bats file_tags=docker-image
+setup_file() {
+    make -f sample/Makefile image-build >&2
+}
+setup() {
+    load 'test_helper/common-setup'
+    _common_setup
+}
+teardown_file() {
+    make -f sample/Makefile irm
+}
+
+# Targets.
+#
+# bats test_tags=targets,docker-targets,image-build,dry-run
+@test "hello-world Docker image build: dry" {
+    MAKESTER__DOCKER=docker run make -f sample/Makefile image-build --dry-run
+    assert_output --regexp 'docker build -t supa-cool-repo/my-project:[0-9a-z]{7} sample'
+    [ "$status" -eq 0 ]
+}
+
+# bats test_tags=targets,docker-targets,image-search,dry-run
+@test "hello-world Docker image search: dry" {
+    MAKESTER__DOCKER=docker run make -f sample/Makefile image-search --dry-run
+    assert_output 'docker images "supa-cool-repo/my-project*"'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=targets,docker-targets,image-search
+@test "hello-world Docker image search" {
+    MAKESTER__DOCKER=docker run make -f sample/Makefile image-search
+    assert_output --regexp 'supa-cool-repo/my-project   [0-9a-z]{7}   [0-9a-z]{12}'
+    [ "$status" -eq 0 ]
+}
+
+# bats test_tags=targets,docker-targets,image-run,dry-run
+@test "hello-world Docker image run: dry" {
+    MAKESTER__DOCKER=docker run make -f sample/Makefile run --dry-run
+    assert_output --regexp 'docker run --rm --name mega-container supa-cool-repo/my-project:[0-9a-z]{7}'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=targets,docker-targets,image-run
+@test "hello-world Docker image run" {
+    MAKESTER__DOCKER=docker run make -f sample/Makefile run
+    assert_output --partial 'Hello from Docker!
+This message shows that your installation appears to be working correctly.'
+    [ "$status" -eq 0 ]
+}
+
+# bats test_tags=targets,docker-targets,image-tag,dry-run
+@test "hello-world Docker image tag: dry" {
+    MAKESTER__DOCKER=docker run make -f sample/Makefile image-tag --dry-run
+    assert_output --regexp 'docker tag [0-9a-z]{12} supa-cool-repo/my-project:[0-9a-z]{7}'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=targets,docker-targets,image-tag
+@test "hello-world Docker image tag" {
+    MAKESTER__DOCKER=docker MAKESTER__IMAGE_TARGET_TAG="\$(MAKESTER__VERSION)-\$(MAKESTER__RELEASE_NUMBER)"\
+ run make -f sample/Makefile image-tag --dry-run
+    assert_output --regexp 'docker tag [0-9a-z]{12} supa-cool-repo/my-project:0.0.0-1'
+    [ "$status" -eq 0 ]
+}
+
+# bats test_tags=targets,docker-targets,image-tag-latest,dry-run
+@test "hello-world Docker image tag latest: dry" {
+    MAKESTER__DOCKER=docker run make -f sample/Makefile image-tag-latest --dry-run
+    assert_output --regexp '### Tagging container image "supa-cool-repo/my-project" as "latest"
+docker tag [0-9a-z]{12} supa-cool-repo/my-project:latest'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=targets,docker-targets,image-tag-latest-rm,dry-run
+@test "hello-world Docker image tag latest remove: dry" {
+    MAKESTER__DOCKER=docker run make -f sample/Makefile image-tag-latest-rm --dry-run
+    assert_output '### Removing tag "latest" from container image "supa-cool-repo/my-project"
+docker rmi supa-cool-repo/my-project:latest'
+    [ "$status" -eq 0 ]
+}
+
+# bats test_tags=targets,docker-targets,image-tag-version,dry-run
+@test "hello-world Docker image tag version: dry" {
+    MAKESTER__DOCKER=docker run make -f sample/Makefile image-tag-version --dry-run
+    assert_output --regexp '### Tagging container image "supa-cool-repo/my-project" as "0.0.0-1"
+docker tag [0-9a-z]{12} supa-cool-repo/my-project:0.0.0-1'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=targets,docker-targets,image-tag-version-rm,dry-run
+@test "hello-world Docker image tag version remove: dry" {
+    MAKESTER__DOCKER=docker run make -f sample/Makefile image-tag-version-rm --dry-run
+    assert_output '### Removing tag "0.0.0-1" from container image "supa-cool-repo/my-project"
+docker rmi supa-cool-repo/my-project:0.0.0-1'
+    [ "$status" -eq 0 ]
+}
+
+# bats test_tags=targets,docker-targets,image-tag-main,dry-run
+@test "hello-world Docker image tag main: dry" {
+    MAKESTER__DOCKER=docker run make -f sample/Makefile image-tag-main --dry-run
+    assert_output --regexp '### Tagging container image "supa-cool-repo/my-project" as "0.0.0"
+docker tag [0-9a-z]{12} supa-cool-repo/my-project:0.0.0'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=targets,docker-targets,image-tag-main-rm,dry-run
+@test "hello-world Docker image tag main remove: dry" {
+    MAKESTER__DOCKER=docker run make -f sample/Makefile image-tag-main-rm --dry-run
+    assert_output '### Removing tag "0.0.0" from container image "supa-cool-repo/my-project"
+docker rmi supa-cool-repo/my-project:0.0.0'
+    [ "$status" -eq 0 ]
+}

--- a/tests/test_helper/common-setup.bash
+++ b/tests/test_helper/common-setup.bash
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+_common_setup() {
+    load 'test_helper/bats-support/load'
+    load 'test_helper/bats-assert/load'
+}

--- a/tests/test_makester.bats
+++ b/tests/test_makester.bats
@@ -1,53 +1,31 @@
 # Test runner.
 #
 # Can be executed manually with:
-#   tests/bats/bin/bats tests
+#   tests/bats/bin/bats --file-filter makester tests
 #
-setup() {
-    load 'test_helper/bats-support/load'
-    load 'test_helper/bats-assert/load'
+# bats file_tags=makester
+setup_file() {
     export MAKESTER__WORK_DIR=$(mktemp -d -t makester-XXXXXX)
 }
-
-teardown() {
-    rmdir $MAKESTER__WORK_DIR
+setup() {
+    load 'test_helper/common-setup'
+    _common_setup
+}
+teardown_file() {
+    MAKESTER__PROJECT_DIR=$PWD make -f makefiles/makester.mk -f makefiles/docker.mk -f makefiles/versioning.mk gitversion-clear
+    MAKESTER__WORK_DIR=$MAKESTER__WORK_DIR make -f makefiles/makester.mk makester-work-dir-rm
 }
 
-
-# Makester variables.
+# Makester help.
 #
-# MAKESTER__PRIMED
-# bats test_tags=MAKESTER__PRIMED
-@test "MAKESTER__PRIMED should be set when calling makester.mk" {
-    run make -f makefiles/makester.mk print-MAKESTER__PRIMED
-    assert_output 'MAKESTER__PRIMED=true'
+# bats test_tags=help
+@test "Makester help" {
+    run make -f makefiles/makester.mk makester-help
+    assert_output --partial '(makefiles/makester.mk)'
     [ "$status" -eq 0 ]
 }
 
-# MAKESTER__LOCAL_IP
-# bats test_tags=MAKESTER__LOCAL_IP
-@test "Override MAKESTER__LOCAL_IP override" {
-    MAKESTER__LOCAL_IP=127.0.0.1 run make -f makefiles/makester.mk print-MAKESTER__LOCAL_IP
-    assert_output 'MAKESTER__LOCAL_IP=127.0.0.1'
-    [ "$status" -eq 0 ]
-}
-
-# bats test_tags=MAKESTER__RELEASE_VERSION
-@test "MAKESTER__RELEASE_VERSION defaults to HASH" {
-    run make -f makefiles/makester.mk print-MAKESTER__RELEASE_VERSION
-    assert_output 'MAKESTER__RELEASE_VERSION=<undefined>'
-    [ "$status" -eq 0 ]
-}
-# bats test_tags=MAKESTER__RELEASE_VERSION
-@test "MAKESTER__RELEASE_VERSION override" {
-    MAKESTER__RELEASE_VERSION=override run make -f makefiles/makester.mk print-MAKESTER__RELEASE_VERSION
-    assert_output --regexp '^MAKESTER__RELEASE_VERSION=override$'
-    [ "$status" -eq 0 ]
-}
-
-# Makester dependency checkers.
-#
-# Environment variable checker
+# Environment variable checker.
 # bats test_tags=which-var
 @test "which-var \"BANANA\" is undefined" {
     MAKESTER__VAR=BANANA MAKESTER__VAR_INFO="Just an error message ..." run make -f makefiles/makester.mk which-var
@@ -56,18 +34,47 @@ teardown() {
 ### Just an error message ...'
     [ "$status" -eq 2 ]
 }
-
 # bats test_tags=which-var
 @test "which-var \"MAKESTER__PROJECT_NAME\" is defined" {
     MAKESTER__VAR=MAKESTER__PROJECT_NAME run make -f makefiles/makester.mk which-var
     assert_output --partial '### Checking if "MAKESTER__PROJECT_NAME" is defined ...'
     [ "$status" -eq 0 ]
 }
-
 # bats test_tags=which-var
 @test "which-var \"MAKESTER__WORK_DIR\" is defined" {
     MAKESTER__VAR=MAKESTER__WORK_DIR run make -f makefiles/makester.mk which-var
     assert_output --partial '### Checking if "MAKESTER__WORK_DIR" is defined ...'
+    [ "$status" -eq 0 ]
+}
+
+# Makester variables.
+#
+# MAKESTER__PRIMED
+# bats test_tags=variables,makester-variables,MAKESTER__PRIMED
+@test "MAKESTER__PRIMED should be set when calling makester.mk" {
+    run make -f makefiles/makester.mk print-MAKESTER__PRIMED
+    assert_output 'MAKESTER__PRIMED=true'
+    [ "$status" -eq 0 ]
+}
+
+# MAKESTER__LOCAL_IP
+# bats test_tags=variables,makester-variables,MAKESTER__LOCAL_IP
+@test "Override MAKESTER__LOCAL_IP override" {
+    MAKESTER__LOCAL_IP=127.0.0.1 run make -f makefiles/makester.mk print-MAKESTER__LOCAL_IP
+    assert_output 'MAKESTER__LOCAL_IP=127.0.0.1'
+    [ "$status" -eq 0 ]
+}
+
+# bats test_tags=variables,makester-variables,MAKESTER__RELEASE_VERSION
+@test "MAKESTER__RELEASE_VERSION defaults to HASH" {
+    run make -f makefiles/makester.mk print-MAKESTER__RELEASE_VERSION
+    assert_output 'MAKESTER__RELEASE_VERSION=<undefined>'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=variables,makester-variables,MAKESTER__RELEASE_VERSION
+@test "MAKESTER__RELEASE_VERSION override" {
+    MAKESTER__RELEASE_VERSION=override run make -f makefiles/makester.mk print-MAKESTER__RELEASE_VERSION
+    assert_output --regexp '^MAKESTER__RELEASE_VERSION=override$'
     [ "$status" -eq 0 ]
 }
 

--- a/tests/test_versioning.bats
+++ b/tests/test_versioning.bats
@@ -1,16 +1,17 @@
 # Test runner.
 #
 # Can be executed manually with:
-#   tests/bats/bin/bats tests/test_versioning.bats
+#   tests/bats/bin/bats --file-filter versioning tests
 #
 # bats file_tags=versioning
-setup() {
-    load 'test_helper/bats-support/load'
-    load 'test_helper/bats-assert/load'
+setup_file() {
     export MAKESTER__WORK_DIR=$(mktemp -d -t makester-XXXXXX)
 }
-
-teardown() {
+setup() {
+    load 'test_helper/common-setup'
+    _common_setup
+}
+teardown_file() {
     MAKESTER__PROJECT_DIR=$PWD make -f makefiles/makester.mk -f makefiles/docker.mk -f makefiles/versioning.mk gitversion-clear
     MAKESTER__WORK_DIR=$MAKESTER__WORK_DIR make -f makefiles/makester.mk makester-work-dir-rm
 }
@@ -25,10 +26,9 @@ teardown() {
 include makester/makefiles/docker.mk'
     [ "$status" -eq 2 ]
 }
-
 # bats test_tags=versioning-docker
 @test "Check docker executable dependency with makester.mk" {
-    DOCKER=dummy run make -f makefiles/versioning.mk
+    MAKESTER__DOCKER=dummy run make -f makefiles/versioning.mk
     assert_output --partial '(makefiles/versioning.mk)'
     [ "$status" -eq 0 ]
 }
@@ -36,59 +36,63 @@ include makester/makefiles/docker.mk'
 # Versioning variables.
 #
 # MAKESTER__GITVERSION_CONFIG
-# bats test_tags=MAKESTER__GITVERSION_CONFIG
+# bats test_tags=variables,versioning-variables,MAKESTER__GITVERSION_CONFIG
 @test "MAKESTER__GITVERSION_CONFIG default should be set when calling versioning.mk" {
-    DOCKER=dummy run make -f makefiles/makester.mk -f makefiles/versioning.mk print-MAKESTER__GITVERSION_CONFIG
+    MAKESTER__DOCKER=dummy\
+ run make -f makefiles/makester.mk -f makefiles/versioning.mk print-MAKESTER__GITVERSION_CONFIG
     assert_output 'MAKESTER__GITVERSION_CONFIG=GitVersion.yml'
     [ "$status" -eq 0 ]
 }
-# bats test_tags=MAKESTER__GITVERSION_CONFIG
+# bats test_tags=variables,versioning-variables,MAKESTER__GITVERSION_CONFIG
 @test "MAKESTER__GITVERSION_CONFIG override" {
-    DOCKER=dummy MAKESTER__GITVERSION_CONFIG=Override.yml\
+    MAKESTER__DOCKER=dummy MAKESTER__GITVERSION_CONFIG=Override.yml\
  run make -f makefiles/makester.mk -f makefiles/versioning.mk print-MAKESTER__GITVERSION_CONFIG
     assert_output 'MAKESTER__GITVERSION_CONFIG=Override.yml'
     [ "$status" -eq 0 ]
 }
 
 # MAKESTER__GITVERSION_VARIABLE
-# bats test_tags=MAKESTER__GITVERSION_VARIABLE
+# bats test_tags=variables,versioning-variables,MAKESTER__GITVERSION_VARIABLE
 @test "MAKESTER__GITVERSION_VARIABLE default should be set when calling versioning.mk" {
-    DOCKER=dummy run make -f makefiles/makester.mk -f makefiles/versioning.mk print-MAKESTER__GITVERSION_VARIABLE
+    MAKESTER__DOCKER=dummy\
+ run make -f makefiles/makester.mk -f makefiles/versioning.mk print-MAKESTER__GITVERSION_VARIABLE
     assert_output 'MAKESTER__GITVERSION_VARIABLE=AssemblySemFileVer'
     [ "$status" -eq 0 ]
 }
-# bats test_tags=MAKESTER__GITVERSION_VARIABLE
+# bats test_tags=variables,versioning-variables,MAKESTER__GITVERSION_VARIABLE
 @test "MAKESTER__GITVERSION_VARIABLE override" {
-    DOCKER=dummy MAKESTER__GITVERSION_VARIABLE=Override\
+    MAKESTER__DOCKER=dummy MAKESTER__GITVERSION_VARIABLE=Override\
  run make -f makefiles/makester.mk -f makefiles/versioning.mk print-MAKESTER__GITVERSION_VARIABLE
     assert_output 'MAKESTER__GITVERSION_VARIABLE=Override'
     [ "$status" -eq 0 ]
 }
 
 # MAKESTER__GITVERSION_VERSION
-# bats test_tags=MAKESTER__GITVERSION_VERSION
+# bats test_tags=variables,versioning-variables,MAKESTER__GITVERSION_VERSION
 @test "MAKESTER__GITVERSION_VERSION default should be set when calling versioning.mk" {
-    DOCKER=dummy run make -f makefiles/makester.mk -f makefiles/versioning.mk print-MAKESTER__GITVERSION_VERSION
+    MAKESTER__DOCKER=dummy\
+ run make -f makefiles/makester.mk -f makefiles/versioning.mk print-MAKESTER__GITVERSION_VERSION
     assert_output 'MAKESTER__GITVERSION_VERSION=latest'
     [ "$status" -eq 0 ]
 }
-# bats test_tags=MAKESTER__GITVERSION_VERSION
+# bats test_tags=variables,versioning-variables,MAKESTER__GITVERSION_VERSION
 @test "MAKESTER__GITVERSION_VERSION override" {
-    DOCKER=dummy MAKESTER__GITVERSION_VERSION=override\
+    MAKESTER__DOCKER=dummy MAKESTER__GITVERSION_VERSION=override\
  run make -f makefiles/makester.mk -f makefiles/versioning.mk print-MAKESTER__GITVERSION_VERSION
     assert_output 'MAKESTER__GITVERSION_VERSION=override'
     [ "$status" -eq 0 ]
 }
 
-# bats test_tags=MAKESTER__PACKAGE_NAME
+# bats test_tags=variables,versioning-variables,MAKESTER__PACKAGE_NAME
 @test "MAKESTER__PACKAGE_NAME default should be set when calling versioning.mk" {
-    DOCKER=dummy run make -f makefiles/makester.mk -f makefiles/versioning.mk print-MAKESTER__PACKAGE_NAME
+    MAKESTER__DOCKER=dummy\
+ run make -f makefiles/makester.mk -f makefiles/versioning.mk print-MAKESTER__PACKAGE_NAME
     assert_output 'MAKESTER__PACKAGE_NAME=makefiles'
     [ "$status" -eq 0 ]
 }
-# bats test_tags=MAKESTER__PACKAGE_NAME
+# bats test_tags=variables,versioning-variables,MAKESTER__PACKAGE_NAME
 @test "MAKESTER__PACKAGE_NAME override" {
-    DOCKER=dummy MAKESTER__PACKAGE_NAME=override\
+    MAKESTER__DOCKER=dummy MAKESTER__PACKAGE_NAME=override\
  run make -f makefiles/makester.mk -f makefiles/versioning.mk print-MAKESTER__PACKAGE_NAME
     assert_output 'MAKESTER__PACKAGE_NAME=override'
     [ "$status" -eq 0 ]
@@ -104,7 +108,7 @@ include makester/makefiles/docker.mk'
     [ "$status" -eq 0 ]
 }
 
-# bats test_tags=MAKESTER__RELEASE_VERSION,release-version
+# bats test_tags=variables,versioning-variables,MAKESTER__RELEASE_VERSION,release-version
 @test "Makester sample/GitVersion.yml release version" {
     MAKESTER__PROJECT_DIR=$PWD\
  MAKESTER__GITVERSION_CONFIG=sample/GitVersion.yml\
@@ -112,7 +116,7 @@ include makester/makefiles/docker.mk'
 ### MAKESTER__RELEASE_VERSION: "[0-9]+\.[0-9]+\.[0-9a-z]+"'
     [ "$status" -eq 0 ]
 }
-# bats test_tags=MAKESTER__RELEASE_VERSION,release-version
+# bats test_tags=variables,versioning-variables,MAKESTER__RELEASE_VERSION,release-version
 @test "Makester sample/GitVersion.yml release version with overridden version variable" {
     MAKESTER__PROJECT_DIR=$PWD MAKESTER__GITVERSION_CONFIG=sample/GitVersion.yml MAKESTER__GITVERSION_VARIABLE=ShortSha\
  run make -f makefiles/makester.mk -f makefiles/docker.mk -f makefiles/versioning.mk release-version


### PR DESCRIPTION
General refactor and modernisation of the container image management sub-system which includes:
- Remove Podman support as this is too RedHat centric for my liking at this time
- Support for PyPI `docker-compose` has been completely removed as there does not appear to be
a roadmap within that project to move to [docker compose V2](https://docs.docker.com/compose/compose-v2/)
- shift from PyPI `docker-compose` to [docker compose V2](https://docs.docker.com/compose/compose-v2/) which is integrated into the Docker CLI