### PR TITLE
Docker BuildKit Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ make -f sample/Makefile help
 ```
 Build a Docker image based off the "Hello World" image:
 ```
-make -f sample/Makefile build-image
+make -f sample/Makefile image-build
 ```
 ```
 /usr/bin/docker build -t supa-cool-repo/my-project:99296c8 sample
@@ -103,10 +103,9 @@ make submodule-update
 The standard [GNU Makefile variable](https://www.gnu.org/software/make/manual/html_node/Using-Variables.html) convention is adhered to within the project. Makester introduces special purpose variables are denoted as `MAKESTER__`. Makester will attempt to provide sane defaults to get you started. However, it is recommended that you override these values in your own project's Makefile to provide more informative context.
 
 Makester special purpose variable values can be viewed any time with the `vars` target:
-> ```
-> make vars
-> ```
-
+```
+make vars
+```
 A description of the Makester special purpose variables follows:
 - `MAKESTER__PROJECT_NAME`: the name of the project. Defaults to the current working directory's basename
 - `MAKESTER__SERVICE_NAME`: a service identifier that defaults to `MAKESTER__PROJECT_NAME`. This can be used to target your container repository and identify your image
@@ -213,7 +212,7 @@ make py
 ### `makefiles/compose.mk`
 To use add `include makester/makefiles/compose.mk` to your `Makefile`.
 
-Traditional Makester capability has supported 
+Traditional Makester capability has supported
 [docker compose](https://docs.docker.com/engine/reference/commandline/compose/) capability as a basic
 multi-container orchestration facility. Makester strategy is to move more into the Kubernetes space so support
 for `makefiles/compose.mk` will continue to diminish over time.
@@ -262,11 +261,15 @@ make compose-config
 #### Command Reference
 ##### Build your Docker Image
 ```
-make build-image
+make image-build
 ```
-The `build-image` target can be controlled by overrding the `MAKESTER__BUILD_COMMAND` parameter in your `Makefile`. For example:
+The `image-image` target can be controlled by overrding the `MAKESTER__BUILD_COMMAND` parameter in your `Makefile`. For example:
 ```
 MAKESTER__BUILD_COMMAND := $(MAKESTER__DOCKER) build -t $(MAKESTER__SERVICE_NAME):$(HASH) .
+```
+Alternatively, leverage the features provided by [BuildKit](https://docs.docker.com/build/buildkit/):
+```
+make image-buildx
 ```
 ##### Run your Docker Images as a Container
 ```

--- a/makefiles/docker.mk
+++ b/makefiles/docker.mk
@@ -16,7 +16,9 @@ MAKESTER__IMAGE_TARGET_TAG ?= $(HASH)
 
 MAKESTER__RUN_COMMAND ?= $(MAKESTER__DOCKER) run --rm --name $(MAKESTER__CONTAINER_NAME) $(MAKESTER__SERVICE_NAME):$(HASH)
 
-MAKESTER__BUILD_COMMAND ?= $(MAKESTER__DOCKER) build -t $(MAKESTER__SERVICE_NAME):$(HASH) .
+MAKESTER__BUILD_CONTEXT ?= build
+MAKESTER__BUILD_PATH ?= .
+MAKESTER__BUILD_COMMAND ?= $(MAKESTER__DOCKER) $(MAKESTER__BUILD_CONTEXT) -t $(MAKESTER__SERVICE_NAME):$(MAKESTER__IMAGE_TARGET_TAG) $(MAKESTER__BUILD_PATH)
 
 # 20221027: Introduced target grouping for "image" related items.
 is image-search si search-image:
@@ -24,6 +26,9 @@ is image-search si search-image:
 
 ib image-build bi build-image:
 	$(MAKESTER__BUILD_COMMAND)
+
+ibx image-buildx: MAKESTER__BUILD_CONTEXT := buildx build
+ibx image-buildx: image-build
 
 irm image-rm rmi rm-image:
 	$(MAKESTER__DOCKER) rmi $(MAKESTER__IMAGE_TAG_ALIAS)
@@ -110,6 +115,7 @@ docker-help:
   container-status     Check container $(MAKESTER__CONTAINER_NAME) run status\n\
   container-stop       Stop container $(MAKESTER__CONTAINER_NAME)\n\
   image-build          Build docker image and tag as $(MAKESTER__IMAGE_TAG_ALIAS) (alias bi)\n\
+  image-buildx         Build docker image and tag as $(MAKESTER__IMAGE_TAG_ALIAS) with BuildKit\n\
   image-push           Push image \"$(MAKESTER__IMAGE_TAG_ALIAS)\"\n\
   image-rm             Delete docker image \"$(MAKESTER__IMAGE_TAG_ALIAS)\" (alias rmi)\n\
   image-rm-dangling    Remove all dangling images\n\

--- a/tests/test_docker.bats
+++ b/tests/test_docker.bats
@@ -124,3 +124,21 @@ include makester/makefiles/makester.mk'
     assert_output 'docker tag  makester:0.0.0-1'
     [ "$status" -eq 0 ]
 }
+
+# bats test_tags=targets,docker-targets,image-buildx,dry-run
+@test "Default Docker image buildx: dry" {
+    MAKESTER__PROJECT_NAME=makester\
+ MAKESTER__DOCKER=docker\
+ run make -f makefiles/makester.mk -f makefiles/docker.mk image-buildx --dry-run
+    assert_output --regexp 'docker buildx build -t makester:[0-9a-z]{7} .'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=targets,docker-targets,image-buildx,dry-run
+@test "Docker image buildx overridden tag: dry" {
+    MAKESTER__PROJECT_NAME=makester\
+ MAKESTER__DOCKER=docker\
+ MAKESTER__IMAGE_TARGET_TAG="\$(MAKESTER__VERSION)-\$(MAKESTER__RELEASE_NUMBER)"\
+ run make -f makefiles/makester.mk -f makefiles/docker.mk image-buildx --dry-run
+    assert_output 'docker buildx build -t makester:0.0.0-1 .'
+    [ "$status" -eq 0 ]
+}

--- a/tests/test_docker_image.bats
+++ b/tests/test_docker_image.bats
@@ -1,7 +1,7 @@
 # Test runner.
 #
 # Can be executed manually with:
-#   tests/bats/bin/bats --filter-tags docker_sample tests
+#   tests/bats/bin/bats --filter-tags docker-image tests
 #
 # bats file_tags=docker-image
 setup_file() {
@@ -21,6 +21,13 @@ teardown_file() {
 @test "hello-world Docker image build: dry" {
     MAKESTER__DOCKER=docker run make -f sample/Makefile image-build --dry-run
     assert_output --regexp 'docker build -t supa-cool-repo/my-project:[0-9a-z]{7} sample'
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=targets,docker-targets,image-build,dry-run
+@test "hello-world Docker image build with Dockerfile PATH override: dry" {
+    MAKESTER__BUILD_PATH=sample MAKESTER__DOCKER=docker MAKESTER__REPO_NAME=supa-cool-repo MAKESTER__PROJECT_NAME=my-project\
+ run make -f makefiles/makester.mk -f makefiles/docker.mk image-buildx --dry-run
+    assert_output --regexp 'docker buildx build -t supa-cool-repo/my-project:[0-9a-z]{7} sample'
     [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
Extend container image build to support [BuildKit](https://docs.docker.com/build/buildkit/).