### PR TITLE
Defect: MAKESTER__PROJECT_DIR should default to PWD

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ A description of the Makester special purpose variables follows:
 - `MAKESTER__WORK_DIR`: Working area that Makester uses to store information (defaults to `$PWD/.makester`).
   > **_NOTE:_** Be sure to add the location of `MAKESTER__WORK_DIR` into your project's `.gitignore`.
 
-- `MAKESTER__K8S_MANIFESTS`: location of your project's Kubernetes manifests (defaults to `$MAKESTER__WORK_DIR/k8s/manifests`).
+- `MAKESTER__K8S_MANIFESTS`: Location of your project's Kubernetes manifests (defaults to `$MAKESTER__WORK_DIR/k8s/manifests`).
+- `MAKESTER__PROJECT_DIR`: The home directory of the project (defaults to `$PWD` or the top level
+  of where your project's `.git` directory can be found).
 
 ### Makester Default Virtual Environment
 `Makester` provides a Python virtual environment that adds dependencies that are used by `Makester` to get things done. First, you need to place the following target in your `Makefile`:

--- a/makefiles/makester.mk
+++ b/makefiles/makester.mk
@@ -32,7 +32,7 @@ endif
 # Simulate PyPI package naming convention (replacing hyphens with underscores).
 MAKESTER__PACKAGE_NAME ?= $(shell echo $(MAKESTER__PROJECT_NAME) | tr - _)
 
-MAKESTER__PROJECT_DIR ?= $(PWD)/$(shell echo $(MAKESTER__PROJECT_NAME) | tr A-Z a-z | tr - _)
+MAKESTER__PROJECT_DIR ?= $(PWD)
 
 # MAKESTER__SERVICE_NAME supports optional MAKESTER__REPO_NAME.
 ifeq ($(strip $(MAKESTER__SERVICE_NAME)),)

--- a/tests/test_makester.bats
+++ b/tests/test_makester.bats
@@ -91,6 +91,19 @@ teardown_file() {
     [ "$status" -eq 0 ]
 }
 
+# bats test_tags=variables,makester-variables,MAKESTER__PROJECT_DIR
+@test "MAKESTER__PROJECT_DIR should be set when calling makester.mk" {
+    run make -f makefiles/makester.mk print-MAKESTER__PROJECT_DIR
+    assert_output --regexp "MAKESTER__PROJECT_DIR=$PWD"
+    [ "$status" -eq 0 ]
+}
+# bats test_tags=variables,makester-variables,MAKESTER__PROJECT_DIR
+@test "MAKESTER__PROJECT_DIR override" {
+    MAKESTER__PROJECT_DIR=dummy run make -f makefiles/makester.mk print-MAKESTER__PROJECT_DIR
+    assert_output --regexp 'MAKESTER__PROJECT_DIR=dummy'
+    [ "$status" -eq 0 ]
+}
+
 # Executable checker.
 # bats test_tags=check-exe
 @test "check-exe rule for \"GIT\" finds the executable" {


### PR DESCRIPTION
`MAKESTER__PROJECT_DIR` was being inadvertently overridden in `makefiles/python-venv.mk`.