### PR TITLE
GitVersion release branch support for main-line releases

### DIFF
--- a/sample/GitVersion.yml
+++ b/sample/GitVersion.yml
@@ -80,3 +80,14 @@ branches:
     is-release-branch: true
     pre-release-weight: 1000
     source-branches: ['main']
+  release:
+    regex: ^release(|s)?[/-]
+    mode: ContinuousDelivery
+    tag: ''
+    increment: Patch
+    prevent-increment-of-merged-branch-version: true
+    track-merge-target: false
+    source-branches: [ 'develop', 'main', 'release' ]
+    tracks-release-branches: false
+    is-release-branch: true
+    is-mainline: false


### PR DESCRIPTION
New `release` section to version increment main-line releases independent from your main-line branch. This mitigates the need to make changes directly to your main branch.